### PR TITLE
Generate UI Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Modern Javascript Stack
 - [Dependencies/ third party library](https://github.com/ekovegeance/Fullstack-Nextjs-Templates/blob/main/package.json)
 
 With shadcn/ui [Beautifully designed components that you can copy and paste into your apps. Accessible. Customizable. Open Source.](https://ui.shadcn.com/) 
+Generate UI [v0](https://v0.dev/https://v0.dev/)
 
 ## Features
 - Auth (Credential, Github Sign In)


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file in the `Modern Javascript Stack` section. The change adds a link to the Generate UI v0 website.

Changes in `README.md`:

* Added a link to [Generate UI v0](https://v0.dev/https://v0.dev/) under the shadcn/ui section.
